### PR TITLE
Add support for nested colors to easily add color radix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,44 @@ pnpm i -D tailwind-easy-theme colord
 ## Usage
 
 ```javascript
-const { Theme } = require('./build/index.js');
+const { Theme } = require("tailwind-easy-theme");
+const colors = require("tailwindcss/colors");
 
-const theme = new Theme({
-  primary: '#ff0000',
-});
+const themes = {
+  light: {
+    somecolor: "#e9e6ff",
+    blue: colors.blue
+    primary: {
+      100: "#ffcccc",
+      200: "#ff9999",
+      300: "#ff6666",
+      400: "#ff3333",
+      500: "#ff0000",
+      600: "#cc0000",
+      700: "#990000",
+      800: "#660000",
+      900: "#330000"
+    },
+  },
+  dark: {
+    primary: {
+      DEFAULT: "#0f172a",
+      950: "#f8fafc",
+      900: "#f1f5f9",
+      800: "#e2e8f0",
+      700: "#cbd5e1",
+      600: "#94a3b8",
+      500: "#64748b",
+      400: "#475569",
+      300: "#334155",
+      200: "#1e293b",
+      100: "#0f172a",
+      50: "#020617",
+    },
+  },
+};
+
+const theme = new Theme(themes.light);
 
 const darkMode = theme.variant(
   {

--- a/README.md
+++ b/README.md
@@ -7,48 +7,28 @@ pnpm i -D tailwind-easy-theme colord
 ## Usage
 
 ```javascript
-const { Theme } = require("tailwind-easy-theme");
-const colors = require("tailwindcss/colors");
+const { Theme } = require('tailwind-easy-theme');
 
-const themes = {
-  light: {
-    somecolor: "#e9e6ff",
-    blue: colors.blue
-    primary: {
-      100: "#ffcccc",
-      200: "#ff9999",
-      300: "#ff6666",
-      400: "#ff3333",
-      500: "#ff0000",
-      600: "#cc0000",
-      700: "#990000",
-      800: "#660000",
-      900: "#330000"
-    },
+const theme = new Theme({
+  somecolor: '#e9e6ff',
+  primary: {
+    DEFAULT: '#ffcccc',
+    100: '#ffcccc',
+    200: '#ff9999',
+    300: '#ff6666',
+    400: '#ff3333',
   },
-  dark: {
-    primary: {
-      DEFAULT: "#0f172a",
-      950: "#f8fafc",
-      900: "#f1f5f9",
-      800: "#e2e8f0",
-      700: "#cbd5e1",
-      600: "#94a3b8",
-      500: "#64748b",
-      400: "#475569",
-      300: "#334155",
-      200: "#1e293b",
-      100: "#0f172a",
-      50: "#020617",
-    },
-  },
-};
-
-const theme = new Theme(themes.light);
+});
 
 const darkMode = theme.variant(
   {
-    primary: '#0000ff',
+    primary: {
+      DEFAULT: '#0f172a',
+      400: '#475569',
+      300: '#334155',
+      200: '#1e293b',
+      100: '#0f172a',
+    },
   },
   {
     mediaQuery: '@media (prefers-color-scheme: dark)',
@@ -57,7 +37,7 @@ const darkMode = theme.variant(
 
 const coolTheme = theme.variant(
   {
-    primary: '#00ff00',
+    somecolor: '#555',
   },
   {
     selector: '[data-theme="cool-theme"]',
@@ -78,27 +58,40 @@ module.exports = {
 };
 ```
 
-This extends your colors with variables that resolve to css variables
-and also adds all the given defaults to the `:root`. The color is converted to
-hsl values, so that opacity works as expected.
+This config create the tailwind classes and generate the necessary css and inject it. The color is converted to hsl values, so that opacity works as expected.
+
+Generated CSS for this example:
 
 ```css
 :root {
-  --color-primary: 0 100% 50%;
+  --color-somecolor: 247 100% 95%;
+  --color-primary: 0 100% 90%;
+  --color-primary-100: 0 100% 90%;
+  --color-primary-200: 0 100% 80%;
+  --color-primary-300: 0 100% 70%;
+  --color-primary-400: 0 100% 60%;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-primary: 240 100% 50%;
+    --color-primary: 222 47% 11%;
+    --color-primary-100: 222 47% 11%;
+    --color-primary-200: 217 33% 17%;
+    --color-primary-300: 215 25% 27%;
+    --color-primary-400: 215 19% 35%;
   }
 }
 
 [data-theme='cool-theme'] {
-  --color-primary: 120 100% 50%;
+  --color-somecolor: 0 0% 33%;
 }
 
 [data-theme='dark'] {
-  --color-primary: 240 100% 50%;
+  --color-primary: 222 47% 11%;
+  --color-primary-100: 222 47% 11%;
+  --color-primary-200: 217 33% 17%;
+  --color-primary-300: 215 25% 27%;
+  --color-primary-400: 215 19% 35%;
 }
 ```
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,25 @@
 const { Theme } = require('./build/index.js');
 
 const theme = new Theme({
-  primary: '#ff0000',
+  somecolor: '#e9e6ff',
+  primary: {
+    DEFAULT: '#ffcccc',
+    100: '#ffcccc',
+    200: '#ff9999',
+    300: '#ff6666',
+    400: '#ff3333',
+  },
 });
 
 const darkMode = theme.variant(
   {
-    primary: '#0000ff',
+    primary: {
+      DEFAULT: '#0f172a',
+      400: '#475569',
+      300: '#334155',
+      200: '#1e293b',
+      100: '#0f172a',
+    },
   },
   {
     mediaQuery: '@media (prefers-color-scheme: dark)',
@@ -15,7 +28,7 @@ const darkMode = theme.variant(
 
 const coolTheme = theme.variant(
   {
-    primary: '#00ff00',
+    somecolor: '#555',
   },
   {
     selector: '[data-theme="cool-theme"]',


### PR DESCRIPTION
Hi there,

Thanks for this awesome little package! It is very easy to use and was exactly what I was looking for.

Currently, this package only supports flat color objects, but it would be useful to allow nested color objects to provide more flexibility and organization in our styles. This pull request adds support for nested color objects by recursively traversing the input ColorList and generating keys with nested names, using the format parent-child. The new implementation still maintains backward compatibility, so existing code should continue to work as expected.