### PR TITLE
Add missing `gradientColorStops` to internal themePropertiesConfig

### DIFF
--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -73,6 +73,10 @@ const themePropertiesConfig: InternalThemePropertiesConfig = {
     prefix: "text-decoration",
     type: ColorProperty,
   },
+  gradientColorStops: {
+    prefix: "gradient",
+    type: ColorProperty,
+  },
 };
 
 export class Theme<T extends ThemeProps = ThemeProps> {

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -77,6 +77,10 @@ const themePropertiesConfig: InternalThemePropertiesConfig = {
     prefix: "gradient",
     type: ColorProperty,
   },
+  fill: {
+    prefix: "fill",
+    type: ColorProperty,
+  },
 };
 
 export class Theme<T extends ThemeProps = ThemeProps> {

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -22,7 +22,7 @@ import { camelToKebab } from "./utils/camelToKebab";
  */
 const themePropertiesConfig: InternalThemePropertiesConfig = {
   colors: {
-    prefix: "colors",
+    prefix: "",
     type: ColorProperty,
   },
   backgroundColor: {


### PR DESCRIPTION
`gradientColorStops` was missing as a color property in the internal `themePropertiesConfig`, meaning any colors specifically set under that theme property were not receiving the special `hsl` color conversion. I double-checked again and I believe this is the only missing color property.