### PR TITLE
Add missing "stroke" color property to default config

### DIFF
--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -73,6 +73,10 @@ const themePropertiesConfig: InternalThemePropertiesConfig = {
     prefix: "text-decoration",
     type: ColorProperty,
   },
+  gradientColorStops: {
+    prefix: "gradient",
+    type: ColorProperty,
+  },
 };
 
 export class Theme<T extends ThemeProps = ThemeProps> {

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -77,6 +77,10 @@ const themePropertiesConfig: InternalThemePropertiesConfig = {
     prefix: "gradient",
     type: ColorProperty,
   },
+  fill: {
+    prefix: "fill",
+    type: ColorProperty,
+  },
 };
 
 export class Theme<T extends ThemeProps = ThemeProps> {

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -81,6 +81,10 @@ const themePropertiesConfig: InternalThemePropertiesConfig = {
     prefix: "fill",
     type: ColorProperty,
   },
+  stroke: {
+    prefix: "stroke",
+    type: ColorProperty,
+  },
 };
 
 export class Theme<T extends ThemeProps = ThemeProps> {

--- a/src/Theme.ts
+++ b/src/Theme.ts
@@ -22,7 +22,7 @@ import { camelToKebab } from "./utils/camelToKebab";
  */
 const themePropertiesConfig: InternalThemePropertiesConfig = {
   colors: {
-    prefix: "colors",
+    prefix: "",
     type: ColorProperty,
   },
   backgroundColor: {


### PR DESCRIPTION
Similar to my last PR, this adds the missing "stroke" color property to the internal "themePropertiesConfig"